### PR TITLE
Add support for OpenAI BASE_URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 OPENAI_API = 
+OPENAI_API_BASE_URL=
 OPENAI_MODEL_ENGINE = 'gpt-3.5-turbo'
 SYSTEM_MESSAGE = 'You are a helpful assistant.'
 DISCORD_TOKEN = 

--- a/.gitignore
+++ b/.gitignore
@@ -117,5 +117,5 @@ dist
 .yarn/install-state.gz
 .pnp.*
 
-
-
+# python
+*.pyc

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-openai==0.26.5
+openai==0.27.0
 requests==2.28.2
 discord.py==2.1.1
 python-dotenv==0.21.1

--- a/src/models.py
+++ b/src/models.py
@@ -1,3 +1,5 @@
+import os
+
 from typing import List, Dict
 import openai
 
@@ -13,6 +15,9 @@ class ModelInterface:
 class OpenAIModel(ModelInterface):
     def __init__(self, api_key: str, model_engine: str, image_size: str = '512x512'):
         openai.api_key = api_key
+        if os.getenv("OPENAI_API_BASE_URL", None):
+            openai.api_base = os.getenv('OPENAI_API_BASE_URL')
+
         self.model_engine = model_engine
         self.image_size = image_size
 


### PR DESCRIPTION
Adds support to set base_url. Enables locally hosted versions of OpenAI's API (like https://github.com/keldenl/gpt-llama.cpp) to work out of the box with a simple `.env` config.